### PR TITLE
Added settings saving feature

### DIFF
--- a/PyPad PRO/PyPad.pyw
+++ b/PyPad PRO/PyPad.pyw
@@ -26,8 +26,9 @@ class PyPadPRO():
 
 
         photo = PhotoImage(file = "PyPad.png")
+        file_path = sys.argv[1] if len(sys.argv) > 1 else None
         root.iconphoto(False, photo)
-        file_menu.main(root, text, menubar)
+        file_menu.main(root, text, menubar, file_path)
         edit_menu.main(root, text, menubar)
         format_menu.main(root, text, menubar)
         help_menu.main(root, text, menubar)

--- a/PyPad PRO/edit_menu.py
+++ b/PyPad PRO/edit_menu.py
@@ -84,4 +84,4 @@ def main(root, text, menubar):
 
 
 if __name__ == "__main__":
-    print("Please run 'PyPad.py'")
+    print("Please run 'PyPad.pyw'")

--- a/PyPad PRO/file_menu.py
+++ b/PyPad PRO/file_menu.py
@@ -73,4 +73,4 @@ def main(root, text, menubar):
 
 
 if __name__ == "__main__":
-    print("Please run 'PyPad.py'")
+    print("Please run 'PyPad.pyw'")

--- a/PyPad PRO/file_menu.py
+++ b/PyPad PRO/file_menu.py
@@ -36,10 +36,13 @@ class File():
             self.filename = None
         else:
             self.filename = f.name
-            t = f.read()
-            self.text.delete(0.0, END)
-            self.text.insert(0.0, t)
-            self.root.title(os.path.basename(self.filename) + " - PyPad PRO")
+            self.readFile(f)
+
+    def readFile(self, f):
+        t = f.read()
+        self.text.delete(0.0, END)
+        self.text.insert(0.0, t)
+        self.root.title(os.path.basename(self.filename) + " - PyPad PRO")
 
     def quit(self, *args):
         entry = askyesno(title="Quit", message="Are you sure you want to quit?")
@@ -52,9 +55,14 @@ class File():
         self.root = root
 
 
-def main(root, text, menubar):
+def main(root, text, menubar, file_path):
     filemenu = Menu(menubar, tearoff=False)
     objFile = File(text, root)
+    if file_path:
+        objFile.filename = file_path
+        with open(file_path, "r") as f:
+            objFile.readFile(f)
+
     filemenu.add_command(label="New", command=objFile.newFile, accelerator="Ctrl+N")
     filemenu.add_command(label="Open", command=objFile.openFile, accelerator="Ctrl+O")
     filemenu.add_command(label="Save", command=objFile.saveFile, accelerator="Ctrl+S")

--- a/PyPad PRO/format_menu.py
+++ b/PyPad PRO/format_menu.py
@@ -6,6 +6,7 @@ from tkinter.scrolledtext import *
 import time
 import sys
 
+from settings import SettingsManager
 
 class Format():
     def __init__(self, text):
@@ -14,11 +15,13 @@ class Format():
     def changeBg(self):
         (triple, hexstr) = askcolor()
         if hexstr:
+            SettingsManager.change_setting("background_color", hexstr) #update settings
             self.text.config(bg=hexstr)
 
     def changeFg(self):
         (triple, hexstr) = askcolor()
         if hexstr:
+            SettingsManager.change_setting("font_color", hexstr) #update settings
             self.text.config(fg=hexstr)
 
     def bold(self, *args):  # Works only if text is selected
@@ -84,6 +87,7 @@ class Format():
 
 def main(root, text, menubar):
     objFormat = Format(text)
+    SettingsManager.setup(objFormat) # setup the settings
 
     fontoptions = families(root)
     font = Font(family="Arial", size=10)
@@ -121,6 +125,6 @@ def main(root, text, menubar):
     root.config(menu=menubar)
 
 
-if __name__ == "__main":
-    print("Please run 'main.py'")
+if __name__ == "__main__":
+    print("Please run 'PyPad.pyw'")
 

--- a/PyPad PRO/format_menu.py
+++ b/PyPad PRO/format_menu.py
@@ -87,11 +87,12 @@ class Format():
 
 def main(root, text, menubar):
     objFormat = Format(text)
-    SettingsManager.setup(objFormat) # setup the settings
 
     fontoptions = families(root)
     font = Font(family="Arial", size=10)
     text.configure(font=font)
+
+    SettingsManager.setup(objFormat, font) # setup the settings
 
     formatMenu = Menu(menubar, tearoff=False)
 
@@ -99,9 +100,9 @@ def main(root, text, menubar):
     ssubmenu = Menu(formatMenu, tearoff=False)
 
     for option in fontoptions:
-        fsubmenu.add_command(label=option, command=lambda option=option: font.configure(family=option))
+        fsubmenu.add_command(label=option, command=lambda option=option: SettingsManager.change_font(font, "font_family", option))
     for value in range(1, 31):
-        ssubmenu.add_command(label=str(value), command=lambda value=value: font.configure(size=value))
+        ssubmenu.add_command(label=str(value), command=lambda value=value: SettingsManager.change_font(font, "font_size", value))
 
     formatMenu.add_command(label="Change Background", command=objFormat.changeBg)
     formatMenu.add_command(label="Change Font Color", command=objFormat.changeFg)

--- a/PyPad PRO/help_menu.py
+++ b/PyPad PRO/help_menu.py
@@ -21,4 +21,4 @@ def main(root, text, menubar):
 
 
 if __name__ == "__main__":
-    print("Please run 'PyPad.py'")
+    print("Please run 'PyPad.pyw'")

--- a/PyPad PRO/settings.py
+++ b/PyPad PRO/settings.py
@@ -6,7 +6,7 @@ class SettingsManager:
 	settings_file = os.path.join(save_dir, 'settings.json') # settings file is 'settings.json' in save directory 
 
 	@classmethod
-	def setup(cls, objFormat):
+	def setup(cls, objFormat, font):
 		"""A method to setup the settings"""
 		#check if save directory exists, if not then create it
 		if not os.path.exists(cls.save_dir): os.makedirs(cls.save_dir)
@@ -15,12 +15,14 @@ class SettingsManager:
 		if not os.path.exists(cls.settings_file):
 			default_settings = {
 				"background_color": "#ffffff",
-				"font_color": "#000000"
+				"font_color": "#000000",
+				"font_family": "Arial",
+				"font_size": 10
 			}
 			# writes the default setting into the settings.json file with json format
 			json.dump(default_settings, open(cls.settings_file, "w"))
 
-		cls.load_setting(objFormat) #load settings
+		cls.load_setting(objFormat, font) #load settings
 
 	@classmethod
 	def change_setting(cls, setting, value):
@@ -30,11 +32,20 @@ class SettingsManager:
 		json.dump(settings_dict, open(cls.settings_file, "w")) #save the changed settings
 
 	@classmethod
-	def load_setting(cls, objFormat):
+	def change_font(cls, font, setting, value):
+		"""A method to change the value of a font setting and save it into settings.json"""
+		if setting == "font_family": font.configure(family=value)
+		if setting == "font_size": font.configure(size=value)
+		cls.change_setting(setting, value)
+
+	@classmethod
+	def load_setting(cls, objFormat, font):
 		"""A method to load the settings from settings.json"""
 		settings_dict = json.load(open(cls.settings_file, 'r')) # retrieve settings from settings.json
 		objFormat.text.config(bg=settings_dict["background_color"])
 		objFormat.text.config(fg=settings_dict["font_color"])
+		font.configure(family=settings_dict["font_family"])
+		font.configure(size=settings_dict["font_size"])
 
 if __name__ == "__main__":
     print("Please run 'PyPad.pyw'")

--- a/PyPad PRO/settings.py
+++ b/PyPad PRO/settings.py
@@ -1,0 +1,40 @@
+import os, json
+
+class SettingsManager:
+	"""A class that manages the settings/saves"""
+	save_dir = os.path.join(os.environ['LOCALAPPDATA'], 'PyPadPRO') # save directory is in %localappdata%/PyPadPRO
+	settings_file = os.path.join(save_dir, 'settings.json') # settings file is 'settings.json' in save directory 
+
+	@classmethod
+	def setup(cls, objFormat):
+		"""A method to setup the settings"""
+		#check if save directory exists, if not then create it
+		if not os.path.exists(cls.save_dir): os.makedirs(cls.save_dir)
+
+		#check if settings file exists, if not then create one with default settings
+		if not os.path.exists(cls.settings_file):
+			default_settings = {
+				"background_color": "#ffffff",
+				"font_color": "#000000"
+			}
+			# writes the default setting into the settings.json file with json format
+			json.dump(default_settings, open(cls.settings_file, "w"))
+
+		cls.load_setting(objFormat) #load settings
+
+	@classmethod
+	def change_setting(cls, setting, value):
+		"""A method to change the value of a setting in settings"""
+		settings_dict = json.load(open(cls.settings_file, 'r')) # retrieve settings from settings.json
+		settings_dict[setting] = value #change the settings
+		json.dump(settings_dict, open(cls.settings_file, "w")) #save the changed settings
+
+	@classmethod
+	def load_setting(cls, objFormat):
+		"""A method to load the settings from settings.json"""
+		settings_dict = json.load(open(cls.settings_file, 'r')) # retrieve settings from settings.json
+		objFormat.text.config(bg=settings_dict["background_color"])
+		objFormat.text.config(fg=settings_dict["font_color"])
+
+if __name__ == "__main__":
+    print("Please run 'PyPad.pyw'")


### PR DESCRIPTION
background color and font color, size, family settings will now be saved
the settings are saved in %localappdata%/PyPadPRO/settings.json
main code for settings saving is in settings.py

minor changes to the ending of your other files
where it said "Please run 'PyPad.py'" when it is supposed to be "Please run 'PyPad.pyw'"
and also fixed the if ____name____ == "____main____": part for format_menu